### PR TITLE
fix: encode urls for go

### DIFF
--- a/pkg/parser/gomod.go
+++ b/pkg/parser/gomod.go
@@ -16,6 +16,7 @@
 package parser
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/stacklok/trusty-action/pkg/types"
@@ -52,10 +53,14 @@ func ParseGoMod(content string) ([]types.Dependency, error) {
 					depName = parts[0]
 					depVersion = parts[1]
 				} else { // Inline require
+					if len(parts) < 3 {
+						continue // Skip malformed inline requires that do not have both a name and a version
+					}
 					depName = parts[1]
 					depVersion = parts[2]
 				}
-				deps = append(deps, types.Dependency{Name: depName, Version: depVersion})
+				encodedDepName := url.PathEscape(depName)
+				deps = append(deps, types.Dependency{Name: encodedDepName, Version: depVersion})
 			}
 		}
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -36,7 +36,7 @@ func TestParse(t *testing.T) {
 			filename: "go.mod",
 			content:  "module example.com\n\ngo 1.16\n\nrequire (\n\tgithub.com/google/go-github/v60 v60.0.0\n)",
 			expected: []types.Dependency{
-				{Name: "github.com/google/go-github/v60", Version: "v60.0.0"},
+				{Name: "github.com%2Fgoogle%2Fgo-github%2Fv60", Version: "v60.0.0"},
 			},
 			ecosystem: "go",
 			err:       nil,


### PR DESCRIPTION
trusty api expects to receive the url in an encoded format

Closes: #2