### PR TITLE
Replace unpinned actions with pinned action

### DIFF
--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -1,27 +1,21 @@
 name: Test and Build
-
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
-
+    branches: [main]
 jobs:
   test:
     name: Run Go Tests
     runs-on: ubuntu-latest
-
     steps:
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: '1.22.1'
-
-    - name: Get dependencies
-      run: go mod tidy
-
-    - name: Run tests
-      run: go test ./... -v
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - name: Set up Go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
+        with:
+          go-version: '1.22.1'
+      - name: Get dependencies
+        run: go mod tidy
+      - name: Run tests
+        run: go test ./... -v


### PR DESCRIPTION
This is a Minder automated pull request.

This pull request replaces references to actions by tag to references to actions by SHA.

Verifies that any actions use pinned tags
Pinning an action to a full length commit SHA is currently the only way to use
an action as an immutable release. Pinning to a particular SHA helps mitigate
the risk of a bad actor adding a backdoor to the action's repository, as they
would need to generate a SHA-1 collision for a valid Git object payload.
When selecting a SHA, you should verify it is from the action's repository
and not a repository fork.

For more information, see
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
