### PR TITLE
Deflake TestParse

### DIFF
--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/stacklok/trusty-action/pkg/types"
@@ -72,6 +73,10 @@ func TestParse(t *testing.T) {
 
 	for _, test := range tests {
 		deps, ecosystem, err := Parse(test.filename, test.content)
+
+		sort.Slice(deps, func(i, j int) bool { return deps[i].Name < deps[j].Name })
+		sort.Slice(test.expected, func(i, j int) bool { return test.expected[i].Name < test.expected[j].Name })
+
 		if !reflect.DeepEqual(deps, test.expected) {
 			t.Errorf("Expected dependencies %v, but got %v", test.expected, deps)
 		}


### PR DESCRIPTION
This PR deflakes the TestParse test that has been breaking the CI in the the latest pull requests

For example:  https://github.com/stacklok/trusty-action/actions/runs/9454908289/job/26043521472?pr=39

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@stacklok.com>
