### PR TITLE
Use latest major version of `actions/checkout` in example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ jobs:
     name: Check Dependencies with TrustyPkg
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: TrustyPkg Action
         uses: stacklok/trusty-action@v0.0.7


### PR DESCRIPTION
Hey, just a small PR to update the version of `actions/checkout` recommended in the example workflow in the README.md from (the old) v2 to the latest major version (v4).

It seems this example, including the specific `actions/checkout` version, was added in #1 and I couldn't find an explanation for using v2 - hence I figured updating the example should be fine.