### PR TITLE
Enable golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,26 @@
+# Copyright 2024 Stacklok, Inc
+# SPDX-License-Identifier: Apache-2.0
+
+name: golangci-lint
+
+on:
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  golangci:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: false
+      - name: lint
+        uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
+        with:
+          version: v1.61
+          args: --timeout=5m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,166 @@
+---
+run:
+  concurrency: 6
+  timeout: 5m
+issues:
+  exclude-rules:
+    # counterfeiter fakes are usually named 'fake_<something>.go'
+    - path: fake_.*\.go
+      linters:
+        - gocritic
+        - golint
+        - dupl
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    # - depguard
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    # - goconst Disabled temporarily as we need to const away all the relationships
+    - gocritic
+    # - gocyclo Disables until some functions are optimized
+    - godox
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - importas
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - nolintlint
+    - prealloc
+    - predeclared
+    - promlinter
+    # - revive Disabled for now as we have lots of uppercase consts
+    - staticcheck
+    #- stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+    # - cyclop
+    # - errorlint
+    # - exhaustive
+    # - exhaustivestruct
+    # - exportloopref
+    # - forbidigo
+    # - forcetypeassert
+    # - funlen
+    # - gci
+    # - gochecknoglobals
+    # - gochecknoinits
+    # - gocognit
+    # - godot
+    # - goerr113
+    # - gomnd
+    # - ifshort
+    # - lll
+    # - nestif
+    # - nilerr
+    # - nlreturn
+    # - noctx
+    # - paralleltest
+    # - scopelint
+    # - tagliatelle
+    # - testpackage
+    # - thelper
+    # - tparallel
+    # - wastedassign
+    # - wrapcheck
+    # - wsl
+linters-settings:
+  depguard:
+    list-type: blacklist
+    include-go-root: true
+    include-go-std-lib: true
+  gci:
+    no-inline-comments: false
+    no-prefix-comments: true
+    sections:
+      - standard
+      - default
+      - prefix(github.com/stacklok/trusty-action)
+
+    section-separators:
+      - newLine
+  godox:
+    keywords:
+      - BUG
+      - FIXME
+      - HACK
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+  gocritic:
+    enabled-checks:
+      # Diagnostic
+      - commentedOutCode
+      - nilValReturn
+      - sloppyReassign
+      - weakCond
+      - octalLiteral
+
+      # Performance
+      - appendCombine
+      - equalFold
+      - hugeParam
+      - indexAlloc
+      - rangeExprCopy
+      - rangeValCopy
+
+      # Style
+      - boolExprSimplify
+      - commentedOutImport
+      - docStub
+      - emptyFallthrough
+      - emptyStringTest
+      - hexLiteral
+      - methodExprCall
+      - stringXbytes
+      - typeAssertChain
+      - unlabelStmt
+      - yodaStyleExpr
+      # - ifElseChain
+
+      # Opinionated
+      - builtinShadow
+      - importShadow
+      - initClause
+      - nestingReduce
+      - paramTypeCombine
+      - ptrToRefParam
+      - typeUnparen
+      - unnamedResult
+      - unnecessaryBlock
+  nolintlint:
+    # Enable to ensure that nolint directives are all used. Default is true.
+    allow-unused: false
+    # Disable to ensure that nolint directives don't have a leading space. Default is true.
+    # TODO(lint): Enforce machine-readable `nolint` directives
+    allow-leading-space: true
+    # Exclude following linters from requiring an explanation.  Default is [].
+    allow-no-explanation: []
+    # Enable to require an explanation of nonzero length after each nolint directive. Default is false.
+    # TODO(lint): Enforce explanations for `nolint` directives
+    require-explanation: false
+    # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
+    require-specific: true

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func parseScore(scoreStr string, defaultScore string) float64 {
+func parseScore(scoreStr, defaultScore string) float64 {
 	if scoreStr == "" {
 		scoreStr = defaultScore
 	}
@@ -44,7 +44,7 @@ func parseScore(scoreStr string, defaultScore string) float64 {
 	return score
 }
 
-func parseFail(failStr string, defaultFail string) bool {
+func parseFail(failStr, defaultFail string) bool {
 	if failStr == "" {
 		failStr = defaultFail
 	}
@@ -143,7 +143,6 @@ func main() {
 	}
 
 	for _, file := range files {
-
 		baseContent, err := githubClient.GetFileContent(owner, repo, *file.Filename, baseRef)
 		if err != nil {
 			log.Printf("Error fetching base content for %s: %v\n", *file.Filename, err)
@@ -193,6 +192,5 @@ func main() {
 		// In your main application where you call ProcessDependencies
 		trustyapi.BuildReport(ctx, ghClient, owner, repo, prNumber, addedDepNames, ecosystem, globalThreshold, repoActivityThreshold, authorActivityThreshold, provenanceThreshold, typosquattingThreshold,
 			failOnMalicious, failOnDeprecated, failOnArchived)
-
 	}
 }

--- a/pkg/parser/cargo.go
+++ b/pkg/parser/cargo.go
@@ -31,9 +31,11 @@ func ParseCargoToml(content string) ([]types.Dependency, error) {
 		return nil, err
 	}
 
-	var deps []types.Dependency
+	deps := make([]types.Dependency, len(conf.Dependencies))
+	i := 0
 	for name, version := range conf.Dependencies {
-		deps = append(deps, types.Dependency{Name: name, Version: version})
+		deps[i] = types.Dependency{Name: name, Version: version}
+		i++
 	}
 	return deps, nil
 }

--- a/pkg/parser/packagejson.go
+++ b/pkg/parser/packagejson.go
@@ -30,9 +30,11 @@ func ParsePackageJSON(content string) ([]types.Dependency, error) {
 		return nil, err
 	}
 
-	var deps []types.Dependency
+	deps := make([]types.Dependency, len(parsedContent.Dependencies))
+	i := 0
 	for name, version := range parsedContent.Dependencies {
-		deps = append(deps, types.Dependency{Name: name, Version: version})
+		deps[i] = types.Dependency{Name: name, Version: version}
+		i++
 	}
 	return deps, nil
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -41,7 +41,7 @@ var parsingFunctions = map[string]ParsingFunction{
 // the determined ecosystem, and any error encountered.
 // If no matching parsing function is found, it returns an empty slice of
 // dependencies, "none" as the ecosystem, and no error.
-func Parse(filename string, content string) ([]types.Dependency, string, error) {
+func Parse(filename, content string) ([]types.Dependency, string, error) {
 	log.Printf("Parsing file: %s\n", filename)
 	for suffix, function := range parsingFunctions {
 		if strings.HasSuffix(filename, suffix) {

--- a/pkg/parser/pomxml.go
+++ b/pkg/parser/pomxml.go
@@ -42,9 +42,9 @@ func ParsePomXml(content string) ([]types.Dependency, error) {
 		return nil, err
 	}
 
-	var deps []types.Dependency
-	for _, d := range project.Dependencies.Dependency {
-		deps = append(deps, types.Dependency{Name: d.GroupId + ":" + d.ArtifactId, Version: d.Version})
+	deps := make([]types.Dependency, len(project.Dependencies.Dependency))
+	for i, d := range project.Dependencies.Dependency {
+		deps[i] = types.Dependency{Name: d.GroupId + ":" + d.ArtifactId, Version: d.Version}
 	}
 	return deps, nil
 }

--- a/pkg/trustyapi/trusty_structs.go
+++ b/pkg/trustyapi/trusty_structs.go
@@ -106,12 +106,11 @@ type Package struct {
 		Score       float64 `json:"score"`
 		Description struct {
 			Hp struct {
-				Tags     float64 `json:"tags"`
-				Common   float64 `json:"common"`
-				Overlap  float64 `json:"overlap"`
-				Versions float64 `json:"versions"`
-				OverTime struct {
-				} `json:"over_time"`
+				Tags     float64  `json:"tags"`
+				Common   float64  `json:"common"`
+				Overlap  float64  `json:"overlap"`
+				Versions float64  `json:"versions"`
+				OverTime struct{} `json:"over_time"`
 			} `json:"hp"`
 			Score      float64 `json:"score"`
 			Status     string  `json:"status"`
@@ -152,12 +151,11 @@ type Package struct {
 				Score       float64 `json:"score"`
 				Description struct {
 					Hp struct {
-						Tags     float64 `json:"tags"`
-						Common   float64 `json:"common"`
-						Overlap  float64 `json:"overlap"`
-						Versions float64 `json:"versions"`
-						OverTime struct {
-						} `json:"over_time"`
+						Tags     float64  `json:"tags"`
+						Common   float64  `json:"common"`
+						Overlap  float64  `json:"overlap"`
+						Versions float64  `json:"versions"`
+						OverTime struct{} `json:"over_time"`
 					} `json:"hp"`
 					Score      float64 `json:"score"`
 					Status     string  `json:"status"`
@@ -183,12 +181,11 @@ type Package struct {
 			Score       float64 `json:"score"`
 			Description struct {
 				Hp struct {
-					Tags     float64 `json:"tags"`
-					Common   float64 `json:"common"`
-					Overlap  float64 `json:"overlap"`
-					Versions float64 `json:"versions"`
-					OverTime struct {
-					} `json:"over_time"`
+					Tags     float64  `json:"tags"`
+					Common   float64  `json:"common"`
+					Overlap  float64  `json:"overlap"`
+					Versions float64  `json:"versions"`
+					OverTime struct{} `json:"over_time"`
 				} `json:"hp"`
 				Score      float64 `json:"score"`
 				Status     string  `json:"status"`

--- a/pkg/trustyapi/trustyapi_test.go
+++ b/pkg/trustyapi/trustyapi_test.go
@@ -13,7 +13,8 @@ func TestReportBuilder(t *testing.T) {
 	dependencies := []string{"next", "react", "bugsnagmw", "scriptoni", "notifyjs"}
 
 	result, failAction := GenerateReportContent(dependencies, "npm", 5.0, 5.0, 5.0, 5.0, 5.0, true, true, true)
-	// fmt.Println(result) // this is normally used to display and validate the report output, uncomment for debugging
+	//nolint:gocritic // this is normally used to display and validate the report output, uncomment for debugging
+	// fmt.Println(result)
 	if result == "" {
 		t.Errorf("Report is empty")
 	}
@@ -78,8 +79,10 @@ func TestProcessDeprecatedDependencies(t *testing.T) {
 	ecosystem := "npm"
 	scoreThreshold := 5.0
 
-	dependencies := []string{"@types/google-cloud__storage", "cutjs", "scriptoni", "stryker-mocha-framework", "grunt-html-smoosher", "moesif-express", "swagger-methods",
-		"@syncfusion/ej2-heatmap", "@cnbritain/wc-buttons", "gulp-google-cdn"}
+	dependencies := []string{
+		"@types/google-cloud__storage", "cutjs", "scriptoni", "stryker-mocha-framework", "grunt-html-smoosher", "moesif-express", "swagger-methods",
+		"@syncfusion/ej2-heatmap", "@cnbritain/wc-buttons", "gulp-google-cdn",
+	}
 
 	for _, dep := range dependencies {
 		log.Printf("Analyzing dependency: %s\n", dep)
@@ -88,7 +91,6 @@ func TestProcessDeprecatedDependencies(t *testing.T) {
 			t.Errorf("Expected report to contain 'Deprecated' for %s", dep)
 		}
 	}
-
 }
 
 func TestProcessMaliciousDependencies(t *testing.T) {
@@ -104,7 +106,6 @@ func TestProcessMaliciousDependencies(t *testing.T) {
 			t.Errorf("Expected report to contain 'Malicious' for %s", dep)
 		}
 	}
-
 }
 
 func TestProcessSigstoreProvenance(t *testing.T) {
@@ -136,5 +137,4 @@ func TestProcessHistoricalProvenance(t *testing.T) {
 	if !strings.Contains(report, "Number of versions matched to Git Tags/Releases") {
 		t.Errorf("Matched for historical provenance not populated")
 	}
-
 }


### PR DESCRIPTION
This PR enables golangci-lint in the repo. The PR has 3 commits:

1. Adds the linter configuration
2. Fixess all linting errors in the code
3. Adds a presubmit workflow to enforce the linter in new PRs.

Signed-off-by: Adolfo García Veytia (puerco) <puerco@stacklok.com>
