### PR TITLE
Update malicious structure and add support for "deleted" status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/google/go-github/v60 v60.0.0
+	github.com/stacklok/trusty-sdk-go v0.2.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/oauth2 v0.23.0
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stacklok/trusty-sdk-go v0.2.1 h1:4y0nVAmM3nSi3MCU6AO1rY3Iqdg/cQIqVxqxj+977c8=
+github.com/stacklok/trusty-sdk-go v0.2.1/go.mod h1:JjZ0KWyQ5Hbgr9J4vAcKn/uBaWk+WrthWkk7G6HXeMs=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=

--- a/pkg/trustyapi/trusty_structs.go
+++ b/pkg/trustyapi/trusty_structs.go
@@ -15,42 +15,45 @@
 
 package trustyapi
 
+import "github.com/stacklok/trusty-sdk-go/pkg/types"
+
 type Package struct {
 	PackageName string `json:"package_name"`
 	PackageType string `json:"package_type"`
 	PackageData struct {
-		ID                 string `json:"id"`
-		Status             string `json:"status"`
-		StatusCode         any    `json:"status_code"`
-		Name               string `json:"name"`
-		Version            string `json:"version"`
-		Author             string `json:"author"`
-		AuthorEmail        string `json:"author_email"`
-		PackageDescription string `json:"package_description"`
-		RepoDescription    string `json:"repo_description"`
-		Origin             string `json:"origin"`
-		StargazersCount    int    `json:"stargazers_count"`
-		WatchersCount      int    `json:"watchers_count"`
-		HomePage           string `json:"home_page"`
-		HasIssues          bool   `json:"has_issues"`
-		HasProjects        bool   `json:"has_projects"`
-		HasDownloads       bool   `json:"has_downloads"`
-		ForksCount         int    `json:"forks_count"`
-		Archived           bool   `json:"archived"`
-		IsDeprecated       bool   `json:"is_deprecated"`
-		Disabled           bool   `json:"disabled"`
-		OpenIssuesCount    int    `json:"open_issues_count"`
-		Visibility         string `json:"visibility"`
-		Forks              int    `json:"forks"`
-		DefaultBranch      string `json:"default_branch"`
-		NetworkCount       int    `json:"network_count"`
-		SubscribersCount   int    `json:"subscribers_count"`
-		RepositoryName     string `json:"repository_name"`
-		ContributorCount   int    `json:"contributor_count"`
-		PublicRepos        int    `json:"public_repos"`
-		PublicGists        int    `json:"public_gists"`
-		Followers          int    `json:"followers"`
-		Following          int    `json:"following"`
+		ID                 string               `json:"id"`
+		Status             string               `json:"status"`
+		StatusCode         any                  `json:"status_code"`
+		Name               string               `json:"name"`
+		Version            string               `json:"version"`
+		Author             string               `json:"author"`
+		AuthorEmail        string               `json:"author_email"`
+		PackageDescription string               `json:"package_description"`
+		RepoDescription    string               `json:"repo_description"`
+		Origin             string               `json:"origin"`
+		StargazersCount    int                  `json:"stargazers_count"`
+		WatchersCount      int                  `json:"watchers_count"`
+		HomePage           string               `json:"home_page"`
+		HasIssues          bool                 `json:"has_issues"`
+		HasProjects        bool                 `json:"has_projects"`
+		HasDownloads       bool                 `json:"has_downloads"`
+		ForksCount         int                  `json:"forks_count"`
+		Archived           bool                 `json:"archived"`
+		IsDeprecated       bool                 `json:"is_deprecated"`
+		Disabled           bool                 `json:"disabled"`
+		OpenIssuesCount    int                  `json:"open_issues_count"`
+		Visibility         string               `json:"visibility"`
+		Forks              int                  `json:"forks"`
+		DefaultBranch      string               `json:"default_branch"`
+		NetworkCount       int                  `json:"network_count"`
+		SubscribersCount   int                  `json:"subscribers_count"`
+		RepositoryName     string               `json:"repository_name"`
+		ContributorCount   int                  `json:"contributor_count"`
+		PublicRepos        int                  `json:"public_repos"`
+		PublicGists        int                  `json:"public_gists"`
+		Followers          int                  `json:"followers"`
+		Following          int                  `json:"following"`
+		Malicious          *types.MaliciousData `json:"malicious"`
 		Owner              struct {
 			Author          string `json:"author"`
 			AuthorEmail     string `json:"author_email"`

--- a/pkg/trustyapi/trustyapi.go
+++ b/pkg/trustyapi/trustyapi.go
@@ -194,7 +194,7 @@ func ProcessDependency(dep string, ecosystem string, globalThreshold float64, re
 	reportBuilder.WriteString(fmt.Sprintf("### :package: [%s](https://www.trustypkg.dev/%s/%s) - %.2f\n\n", dep, ecosystem, dep, result.Summary.Score))
 
 	// Highlight if the package is malicious, deprecated or archived
-	if result.PackageData.Origin == "malicious" {
+	if result.PackageData.Malicious != nil && result.PackageData.Malicious.Source != "" {
 		reportBuilder.WriteString(fmt.Sprintf("⚠ **Malicious** (This package is marked as Malicious. Proceed with extreme caution!) %s\n", getBoolIcon(result.PackageData.Origin == "malicious", failOnMalicious)))
 	}
 	if result.PackageData.IsDeprecated {
@@ -333,6 +333,11 @@ func fetchPackageData(requestURL, dep, ecosystem string, resultChan chan<- Packa
 			switch data.PackageData.Status {
 			case "complete":
 				log.Printf("API request for %s in %s ecosystem complete\n", dep, ecosystem)
+				resultChan <- data
+				close(resultChan)
+				return
+			case "deleted":
+				log.Printf("API request for %s in %s ecosystem complete (package deleted)\n", dep, ecosystem)
 				resultChan <- data
 				close(resultChan)
 				return


### PR DESCRIPTION
This PR fixes two flaking tests that were breaking the CI as the malicious structure has been updated and the trusty API is now marking some packages with the status `deleted`.

Fixes broken CI in https://github.com/stacklok/trusty-action/pull/64